### PR TITLE
actually enclose fs into cycfi, not the std

### DIFF
--- a/include/infra/filesystem.hpp
+++ b/include/infra/filesystem.hpp
@@ -20,14 +20,16 @@
 # endif
 #endif
 
-namespace cycfi {
 #if defined(INFRA_USE_STD_FS)
 # include <filesystem>
+namespace cycfi {
   namespace fs = std::filesystem;
+}
 #else
 # include <ghc/filesystem.hpp>
+namespace cycfi {
   namespace fs = ghc::filesystem;
-#endif
 }
+#endif
 
 #endif


### PR DESCRIPTION
previous commit accidentally put standard library into cycfi