### PR TITLE
build: fix __cplusplus on msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,12 @@ if(INFRA_FORCE_NONSTD_OPTIONAL)
     target_compile_definitions(infra INTERFACE INFRA_FORCE_NONSTD_OPTIONAL)
 endif()
 
+if(MSVC)
+    # MSVC does not correctly report __cplusplus by default, so we need to enable it
+    # see https://docs.microsoft.com/bs-cyrl-ba/cpp/build/reference/zc-cplusplus?view=msvc-160 for details
+   target_compile_options(infra INTERFACE /Zc:__cplusplus)
+endif()
+
 if(INFRA_ADD_FS_LINK)
     include(CheckCXXSymbolExists)
     # ciso646 is empty on C++, which makes it a convenient header for checking


### PR DESCRIPTION
fix `__cplusplus` on msvc

I come here because I find it not using `std::string_view` when compiling `cycfi/elements`. The reason is due to the `__cplusplus` maco:
```cpp
#if (__cplusplus >= 201703L) && (defined(__cpp_lib_string_view) || \
    (defined(__has_include) && __has_include(<string_view>)))
# define INFRA_USE_STD_STRING_VIEW
#endif
```

Actually, I'm not sure if I should change the `CMakeLists` here or modify the `CMakeLists` in `cycfi/elements` directly. You can ignore or modify this PR as you like.