### PR TITLE
CMake: shared options and modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,27 +11,37 @@ endif()
 
 project(infra)
 
-option(INFRA_FORCE_STD_FS "force use of std::filesystem in infra" OFF)
-option(INFRA_FORCE_GHC_FS "force use of ghc::filesystem in infra" OFF)
-option(INFRA_FORCE_STD_STRING_VIEW "force use of std::string_view in infra" OFF)
+option(INFRA_FORCE_STD_FS             "force use of std::filesystem in infra"     OFF)
+option(INFRA_FORCE_GHC_FS             "force use of ghc::filesystem in infra"     OFF)
+option(INFRA_FORCE_STD_STRING_VIEW    "force use of std::string_view in infra"    OFF)
 option(INFRA_FORCE_NONSTD_STRING_VIEW "force use of nonstd::string_view in infra" OFF)
-option(INFRA_FORCE_STD_OPTIONAL "force use of std::optional in infra" OFF)
-option(INFRA_FORCE_NONSTD_OPTIONAL "force use of nonstd::optional in infra" OFF)
+option(INFRA_FORCE_STD_OPTIONAL       "force use of std::optional in infra"       OFF)
+option(INFRA_FORCE_NONSTD_OPTIONAL    "force use of nonstd::optional in infra"    OFF)
 
 # some ranges of GCC and Clang versions require linker flag
 option(INFRA_ADD_FS_LINK "add linker command for standard filesystem library" OFF)
 
-set(INFRA_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include)
-set(INFRA_FILESYSTEM_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/external/filesystem/include)
-set(INFRA_OPTIONAL_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/external/optional-lite/include)
+set(INFRA_HEADER             ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(INFRA_FILESYSTEM_HEADER  ${CMAKE_CURRENT_SOURCE_DIR}/external/filesystem/include)
+set(INFRA_OPTIONAL_HEADER    ${CMAKE_CURRENT_SOURCE_DIR}/external/optional-lite/include)
 set(INFRA_STRING_VIEW_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/external/string-view-lite/include)
+
+# projects common options
+
+# Add our CMake modules to path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+option(CYCFI_ENABLE_GIT_SUBMODULE_CHECK             "check and clone submodules when not available." ON)
+option(CYCFI_ENABLE_LTO                             "enable link time optimization for Elements targets" OFF)
+set   (CYCFI_USE_EMPTY_SOURCE_GROUPS OFF CACHE BOOL "if to use virtual directories")
 
 add_library(infra INTERFACE)
 target_include_directories(infra INTERFACE
    ${INFRA_HEADER}
    ${INFRA_FILESYSTEM_HEADER}
    ${INFRA_OPTIONAL_HEADER}
-   ${INFRA_STRING_VIEW_HEADER})
+   ${INFRA_STRING_VIEW_HEADER}
+)
 target_compile_features(infra INTERFACE cxx_std_14)
 
 if(INFRA_FORCE_STD_FS)
@@ -79,3 +89,17 @@ if(INFRA_ADD_FS_LINK)
 endif()
 
 add_library(cycfi::infra ALIAS infra)
+
+# Add Infra file list to IDE
+
+file(GLOB_RECURSE PROJECT_FILES "${INFRA_HEADER}/**")
+if(CYCFI_USE_EMPTY_SOURCE_GROUPS)
+   source_group("" FILES ${PROJECT_FILES})
+endif()
+add_custom_target(infra_files SOURCES ${PROJECT_FILES})
+
+file(GLOB_RECURSE CMAKE_MODULE_FILES "${CMAKE_SOURCE_DIR}/cmake/**")
+if(CYCFI_USE_EMPTY_SOURCE_GROUPS)
+   source_group("" FILES ${CMAKE_MODULE_FILES})
+endif()
+add_custom_target(cmake_modules SOURCES ${CMAKE_MODULE_FILES})

--- a/cmake/BuildType.cmake
+++ b/cmake/BuildType.cmake
@@ -1,0 +1,9 @@
+set(DEFAULT_BUILD_TYPE "Release")
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+   message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
+   set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE
+      STRING "Choose the type of build." FORCE)
+   # Set the possible values of build type for cmake-gui
+   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()

--- a/cmake/GitUtilities.cmake
+++ b/cmake/GitUtilities.cmake
@@ -1,0 +1,24 @@
+find_package(Git REQUIRED)
+
+####################################################################################################
+#
+# Adds a Git submodule directory to CMake, assuming the Git submodule directory is a CMake project.
+#
+# Usage in CMakeLists.txt:
+#
+# include(AddGitSubmodule.cmake)
+# add_git_submodule(mysubmod_dir)
+#
+# Source:
+# https://gist.github.com/scivision/bb1d47a9529e153617414e91ff5390af
+#
+####################################################################################################
+function(git_submodule_check dir)
+   if(NOT EXISTS "${dir}/CMakeLists.txt")
+      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${dir}
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+         COMMAND_ERROR_IS_FATAL ANY
+      )
+   endif()
+   #add_subdirectory(${dir} EXCLUDE_FROM_ALL)
+endfunction()

--- a/cmake/LICENSE_SFIZZ.md
+++ b/cmake/LICENSE_SFIZZ.md
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2021-2023, sfizz contributors (detailed in AUTHORS.md)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/OptionEx.cmake
+++ b/cmake/OptionEx.cmake
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+# This code is part of the sfizz library and is licensed under a BSD 2-clause
+# license. You should have receive a LICENSE.md file along with the code.
+# If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+# Macro: option_ex(OPTION DOC [CONDITION])
+#    Defines an option, with these characteristics:
+#      - A suffix [default: ON/OFF] is appended to the documentation
+#      - The value is interpreted like a conditional expression
+macro(option_ex option doc)
+    if(${ARGN})
+        set(_value ON)
+    else()
+        set(_value OFF)
+    endif()
+    option("${option}" "${doc} [default: ${_value}]" "${_value}")
+    unset(_value)
+endmacro()


### PR DESCRIPTION
Changed idea, sorry, I do the PR anyway for review so you can comment before apply.

- added shared options: `CYCFI_ENABLE_GIT_SUBMODULE_CHECK` `CYCFI_ENABLE_LTO` `CYCFI_USE_EMPTY_SOURCE_GROUPS` (not INFRA prefixed because it's not targeted to infra)
- added 2 custom targets to display the infra source code (only infra, not also submodules sources) and cmake modules in IDE where possible (Qt Creator, maybe also others)
- some cosmetic/coding style changes, similar to your c++ headers code style vertically aligned (like the one below)
- added modules for the git submodule check, build type<br>and an `option_ex(<option> <doc_string> <bool_condition>)` made by jpcima,<br>which will be used in a following Artist PR this way:
```cmake
option_ex(ARTIST_QUARTZ_2D      "Build Artist using Quartz 2D on macOS." APPLE)
option_ex(ARTIST_SKIA           "Build Artist using Skia."               NOT APPLE)
option_ex(ARTIST_BUILD_EXAMPLES "Build Artist library examples."         ON)
option_ex(ARTIST_BUILD_TESTS    "Build Artist library tests."            ON)
```