### PR TITLE
Make building with ESP-IDF possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,14 @@ if (TARGET infra)
    return()
 endif()
 
-project(infra)
+# Do not include a project name if building for ESP-IDF
+if(DEFINED ENV{IDF_PATH})
+   idf_component_register(
+      INCLUDE_DIRS ./include
+   )
+else()
+   project(infra)
+endif()
 
 option(INFRA_FORCE_STD_FS             "force use of std::filesystem in infra"     OFF)
 option(INFRA_FORCE_GHC_FS             "force use of ghc::filesystem in infra"     OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,14 @@ if (TARGET infra)
    return()
 endif()
 
-# Do not include a project name if building for ESP-IDF
+# Allow building with ESP-IDF
 if(DEFINED ENV{IDF_PATH})
    idf_component_register(
       INCLUDE_DIRS ./include
    )
-else()
-   project(infra)
 endif()
+
+project(infra)
 
 option(INFRA_FORCE_STD_FS             "force use of std::filesystem in infra"     OFF)
 option(INFRA_FORCE_GHC_FS             "force use of ghc::filesystem in infra"     OFF)


### PR DESCRIPTION
This change picks up the ESP-IDF environment variable `IDF_PATH` when building in the ESP-IDF by using the `idf_component_register` directive.